### PR TITLE
feat: update highlight.js to 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/nuxt-community/markdownit-loader#readme",
   "dependencies": {
-    "highlight.js": "^9.12.0",
+    "highlight.js": "^10.5.0",
     "loader-utils": "^1.1.0",
     "markdown-it": "^8.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1827,9 +1827,10 @@ he@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-highlight.js@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+highlight.js@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
+  integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
NPM flags this as vulnerability https://github.com/advisories/GHSA-vfrc-7r7c-w9mx. It also comes up when running `npm audit`